### PR TITLE
Feature/executeflow

### DIFF
--- a/lib/features/flow/presentation/flow_screen/flow_timer_provider.dart
+++ b/lib/features/flow/presentation/flow_screen/flow_timer_provider.dart
@@ -3,52 +3,39 @@ import 'package:noti_flutter/data/auth/auth_repository.dart';
 import 'package:noti_flutter/data/flow/flow_repository.dart';
 import 'package:noti_flutter/models/flow_model.dart';
 
-final flowScreenProvider =
-    StateNotifierProvider<FlowScreenNotifier, FlowState>((ref) {
+final flowTimerProvider =
+    StateNotifierProvider<FlowTimerNotifier, FlowState>((ref) {
   final flowRepository = ref.watch(flowRepositoryProvider);
-  return FlowScreenNotifier(flowRepository);
+  return FlowTimerNotifier(flowRepository);
 });
 
-class FlowScreenNotifier extends StateNotifier<FlowState> {
+class FlowTimerNotifier extends StateNotifier<FlowState> {
   final FlowRepository _flowRepository;
 
-  FlowScreenNotifier(
+  FlowTimerNotifier(
     this._flowRepository,
   ) : super(FlowState());
 
   void setFlowInfo(FlowModel flow) {
     state = state.copyWith(flow: flow);
   }
-
-  Duration updateRemainingTime({
-    required Duration timeLimit,
-    required Duration elapsedTime,
-  }) {
-    state = state.copyWith(remainingTime: timeLimit - elapsedTime);
-
-    return state.remainingTime;
-  }
 }
 
 class FlowState {
   FlowModel? flow;
-  Duration remainingTime;
   bool isLoading;
 
   FlowState({
     this.flow,
-    this.remainingTime = Duration.zero,
     this.isLoading = false,
   });
 
   FlowState copyWith({
     FlowModel? flow,
-    Duration? remainingTime,
     bool? isLoading,
   }) {
     return FlowState(
       flow: flow ?? this.flow,
-      remainingTime: remainingTime ?? this.remainingTime,
       isLoading: isLoading ?? this.isLoading,
     );
   }

--- a/lib/features/flow/presentation/flow_screen/flow_timer_screen.dart
+++ b/lib/features/flow/presentation/flow_screen/flow_timer_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_timer_provider.dart';
 
 class FlowTimerScreen extends ConsumerStatefulWidget {
@@ -11,13 +13,24 @@ class FlowTimerScreen extends ConsumerStatefulWidget {
 }
 
 class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
-  int elapsedSeconds = 0;
-  bool isRunning = false;
-  bool isFocusTime = true;
-  late Timer _timer;
+  int elapsedSeconds = 0; // 타이머가 시작되고 경과된 시간
+  bool isRunning = false; // 타이머가 동작 중인가
+  bool isFocusTime = true; // 현재 집중단계(1단계)인가
+  int round = 1; // 플로우가 몇 회차인지
+  Timer? _timer;
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    // 런타입 에러를 방지하기 위해 타이머가 초기화 된 상태일 때만 타이머 종료 후 디스포스
+    if (_timer != null && _timer!.isActive) {
+      _timer!.cancel();
+    }
+    super.dispose();
+  }
 
   void startTimer() {
-    // 타이머의 제한 시간 설정
+    // 1. 타이머의 제한 시간 설정
     final flowTimerState = ref.watch(flowTimerProvider).flow;
     if (flowTimerState == null) return;
 
@@ -28,15 +41,12 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
       isRunning = true;
     });
 
-    // 타이머 초기화
+    // 2. 타이머 초기화
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       setState(() {
         if (elapsedSeconds >= timeLimit) {
-          isFocusTime = !isFocusTime;
-          stopTimer();
-          resetTimer();
+          goToNextPhase();
           // 알림 발송
-          // 한번 더 하겠습니까 다이얼로그 표시
         } else {
           elapsedSeconds++;
         }
@@ -48,20 +58,42 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
     setState(() {
       isRunning = false;
     });
-    _timer.cancel();
+    _timer!.cancel();
   }
 
-  void resetTimer() {
+  void rewindTimer() {
+    stopTimer();
     setState(() {
       elapsedSeconds = 0;
     });
   }
 
-  // 타이머 종료 (제한 시간 모두 소모시키기)
-  void finishTimer() {
+  // 다음 단계로 건너뛰기
+  void goToNextPhase() {
+    // 1. 휴식단계까지 다 끝났으면 회차++
+    if (!isFocusTime) {
+      round++;
+    }
+
+    // 2. 다음 단계 타이머를 위해 설정 초기화
     isFocusTime = !isFocusTime;
     stopTimer();
-    resetTimer();
+    rewindTimer();
+  }
+
+  // 이전 단계로 돌아가기
+  void backToPreviousPhase() {
+    setState(() {
+      isFocusTime = !isFocusTime;
+    });
+  }
+
+  // 중첩된 삼항연산자 리팩토링: 상태에 따른 버튼 액션 반환 함수
+  VoidCallback? _getButtonAction() {
+    if (isRunning) return goToNextPhase;
+    if (elapsedSeconds > 0) return rewindTimer;
+    if (isFocusTime) return null; // 버튼 비활성화
+    return backToPreviousPhase;
   }
 
   static Map<String, String> formatSecondsToMMSS(int? time) {
@@ -84,7 +116,7 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
     final restTime = formatSecondsToMMSS(
         flowTimerState?.restTime.inSeconds)["minutesWithoutPadLeft"];
 
-    // 타이머의 제한 시간
+    // 현재 단계의 타이머의 제한 시간
     final timeLimit = isFocusTime
         ? flowTimerState?.focusTime.inSeconds
         : flowTimerState?.restTime.inSeconds;
@@ -97,18 +129,31 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
         child: Column(
           spacing: 0,
           children: [
-            Text(
-              "${flowTimerState?.name ?? ""} ${isFocusTime ? "집중" : "휴식"} 시간",
-              style: const TextStyle(fontSize: 24),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  flowTimerState?.name ?? "",
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                Text(
+                  " ${isFocusTime ? "집중" : "휴식"} 시간",
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
             ),
             Text(
               "${remainingTime["minutes"]}:${remainingTime["seconds"]}",
-              style: const TextStyle(fontSize: 64, fontWeight: FontWeight.bold),
+              style: Theme.of(context)
+                  .textTheme
+                  .displayLarge!
+                  .copyWith(letterSpacing: 1),
             ),
             Text(
               '${isFocusTime ? focusTime : restTime}분 중 남은 시간',
-              style: TextStyle(
-                  fontSize: 12, color: Theme.of(context).disabledColor),
+              style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(
               height: 20,
@@ -118,40 +163,90 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
                 borderRadius: BorderRadius.circular(8),
                 color: Colors.white,
               ),
-              padding: const EdgeInsets.all(10),
+              padding: const EdgeInsets.all(12),
               child: Column(
-                spacing: 8,
+                spacing: 10,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text("현재 진행중인 플로우"),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(isFocusTime ? "1단계" : "2단계"),
-                      Text(
-                          "${flowTimerState?.name} ${isFocusTime ? "집중하기" : "휴식하기"} (${isFocusTime ? focusTime : restTime}분)")
-                    ],
-                  ),
-                  LinearProgressIndicator(
-                    value: elapsedSeconds / (timeLimit ?? 1),
-                  ),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Text(
-                        "진행률 %",
-                        style:
-                            TextStyle(color: Theme.of(context).disabledColor),
+                        "현재 진행중인 플로우",
+                        style: Theme.of(context).textTheme.bodyMedium,
                       ),
-                      Text("$focusTime분 집중 후 $restTime분 휴식")
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.baseline,
+                        textBaseline: TextBaseline.alphabetic,
+                        children: [
+                          Text(
+                            "$round",
+                            style:
+                                Theme.of(context).textTheme.bodyLarge!.copyWith(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.bold,
+                                      color: Theme.of(context).primaryColor,
+                                    ),
+                          ),
+                          Text(
+                            " 회차",
+                            style:
+                                Theme.of(context).textTheme.bodyLarge!.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  Column(
+                    spacing: 8,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            isFocusTime ? "1단계" : "2단계",
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          Text(
+                            "${flowTimerState?.name} ${isFocusTime ? "집중하기" : "휴식하기"}(${isFocusTime ? focusTime : restTime}분)",
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ],
+                      ),
+                      LinearProgressIndicator(
+                        color: Theme.of(context).primaryColorDark,
+                        value: timeLimit == null
+                            ? null
+                            : elapsedSeconds / timeLimit,
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            "진행률 ${timeLimit != null ? (elapsedSeconds / timeLimit * 100).round() : ""}%",
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                          Text(
+                            "$focusTime분 집중 후 $restTime분 휴식",
+                            style: Theme.of(context).textTheme.bodySmall,
+                          )
+                        ],
+                      ),
                     ],
                   ),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text(isFocusTime ? "2단계" : "1단계"),
                       Text(
-                          "${flowTimerState?.name} ${isFocusTime ? "휴식하기" : "집중하기"} (${isFocusTime ? restTime : focusTime}분)")
+                        isFocusTime ? "2단계" : "1단계",
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      Text(
+                        "${flowTimerState?.name} ${isFocusTime ? "휴식하기" : "집중하기"}(${isFocusTime ? restTime : focusTime}분)",
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ],
                   ),
                 ],
@@ -171,13 +266,13 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(5),
                       ),
-                      backgroundColor: Theme.of(context).colorScheme.error,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                     ),
                     onPressed: isRunning ? stopTimer : startTimer,
                     child: Text(
                       isRunning ? '일시정지' : "시작하기",
                       style: TextStyle(
-                        color: Theme.of(context).colorScheme.onError,
+                        color: Theme.of(context).colorScheme.onPrimary,
                         fontWeight: FontWeight.bold,
                         fontSize: 16,
                       ),
@@ -191,13 +286,15 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(5),
                       ),
-                      backgroundColor: Theme.of(context).colorScheme.secondary,
+                      backgroundColor: Theme.of(context).focusColor,
                     ),
-                    onPressed: finishTimer,
+                    onPressed: _getButtonAction(),
                     child: Text(
-                      '종료하기',
+                      isRunning
+                          ? "건너뛰기"
+                          : (elapsedSeconds > 0 ? "다시하기" : "이전 단계로"),
                       style: TextStyle(
-                        color: Theme.of(context).colorScheme.onSecondary,
+                        color: Theme.of(context).colorScheme.onPrimary,
                         fontWeight: FontWeight.bold,
                         fontSize: 16,
                       ),
@@ -206,9 +303,120 @@ class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
                 ),
               ],
             ),
+            Expanded(
+              child: Center(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: const Size.fromHeight(50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                    backgroundColor:
+                        Theme.of(context).colorScheme.inverseSurface,
+                  ),
+                  onPressed: () =>
+                      _showExitDialog(context, flowTimerState?.name ?? ""),
+                  child: Text(
+                    "종료하기",
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onInverseSurface,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                    ),
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),
     );
+  }
+
+  // 종료하기 버튼 눌렀을 때 표시될 모달 호출
+  void _showExitDialog(BuildContext context, String flowName) {
+    showDialog(
+      context: context,
+      builder: (context) => FlowEndDialog(
+        round: round,
+        flowName: flowName,
+      ),
+    );
+  }
+}
+
+// 종료하기 버튼 눌렀을 때 표시될 모달. 현재 회차 정보 제공과 기록 저장 여부를 물어보는 역할.
+class FlowEndDialog extends StatelessWidget {
+  final int round;
+  final String flowName;
+
+  const FlowEndDialog({
+    super.key,
+    required this.round,
+    required this.flowName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      icon: const Icon(Icons.timer_outlined),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+      ),
+      backgroundColor: Colors.white,
+      content: Text(
+        textAlign: TextAlign.center,
+        "$flowName 플로우 $round회차 진행 중",
+        style: Theme.of(context).textTheme.titleMedium,
+      ),
+      actions: [
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size.fromHeight(40),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(5),
+            ),
+            backgroundColor: Theme.of(context).colorScheme.primary,
+          ),
+          onPressed: () => _saveAndExit(context),
+          child: Text(
+            "기록 저장 후 종료하기",
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onPrimary,
+              fontWeight: FontWeight.bold,
+              fontSize: 15,
+            ),
+          ),
+        ),
+        const SizedBox(
+          height: 5,
+        ),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size.fromHeight(40),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(5),
+            ),
+            backgroundColor: Theme.of(context).colorScheme.secondary,
+          ),
+          onPressed: () {
+            context.go('/home');
+          },
+          child: Text(
+            "기록 저장하지 않고 종료하기",
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSecondary,
+              fontWeight: FontWeight.bold,
+              fontSize: 15,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _saveAndExit(BuildContext context) {
+    // onSubmit();
+    context.go("/home");
   }
 }

--- a/lib/features/flow/presentation/flow_screen/flow_timer_screen.dart
+++ b/lib/features/flow/presentation/flow_screen/flow_timer_screen.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_timer_provider.dart';
 
-class FlowScreen extends ConsumerStatefulWidget {
-  const FlowScreen({super.key});
+class FlowTimerScreen extends ConsumerStatefulWidget {
+  const FlowTimerScreen({super.key});
 
   @override
-  ConsumerState<FlowScreen> createState() => _FlowScreenState();
+  ConsumerState<FlowTimerScreen> createState() => _FlowTimerScreenState();
 }
 
-class _FlowScreenState extends ConsumerState<FlowScreen> {
+class _FlowTimerScreenState extends ConsumerState<FlowTimerScreen> {
   int elapsedSeconds = 0;
   bool isRunning = false;
   bool isFocusTime = true;

--- a/lib/features/flow/presentation/flow_screen/flow_timer_screen.dart
+++ b/lib/features/flow/presentation/flow_screen/flow_timer_screen.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_screen_provider.dart';
-import 'package:noti_flutter/utils/time_formatter.dart';
+import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_timer_provider.dart';
 
 class FlowScreen extends ConsumerStatefulWidget {
   const FlowScreen({super.key});
@@ -24,6 +23,7 @@ class _FlowScreenState extends ConsumerState<FlowScreen> {
     super.initState();
     timeLimit =
         ref.read(flowScreenProvider).flow?.focusTime.inSeconds ?? 30 * 60;
+    startTimer();
   }
 
   void startTimer() {
@@ -100,12 +100,17 @@ class _FlowScreenState extends ConsumerState<FlowScreen> {
               "${flowState?.name ?? ""} ${isFocusTime ? "집중" : "휴식"} 시간",
               style: const TextStyle(fontSize: 24),
             ),
-            Text("${remainingTime["minutes"]}:${remainingTime["seconds"]}",
-                style: const TextStyle(fontSize: 64)),
+            Text(
+              "${remainingTime["minutes"]}:${remainingTime["seconds"]}",
+              style: const TextStyle(fontSize: 64, fontWeight: FontWeight.bold),
+            ),
             Text(
               '${isFocusTime ? focusTime : restTime}분 중 남은 시간',
               style: TextStyle(
                   fontSize: 12, color: Theme.of(context).disabledColor),
+            ),
+            const SizedBox(
+              height: 20,
             ),
             Container(
               decoration: BoxDecoration(
@@ -149,25 +154,52 @@ class _FlowScreenState extends ConsumerState<FlowScreen> {
                 ],
               ),
             ),
+            const SizedBox(
+              height: 20,
+            ),
             Row(
-              spacing: -20,
+              spacing: 10,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                ElevatedButton(
-                  onPressed: isRunning ? null : startTimer,
-                  child: const Text('Start'),
+                Expanded(
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(50),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5),
+                      ),
+                      backgroundColor: Theme.of(context).colorScheme.error,
+                    ),
+                    onPressed: isRunning ? stopTimer : startTimer,
+                    child: Text(
+                      isRunning ? '일시정지' : "다시 시작하기",
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onError,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
                 ),
-                ElevatedButton(
-                  onPressed: isRunning ? stopTimer : null,
-                  child: const Text('Stop'),
-                ),
-                ElevatedButton(
-                  onPressed: resetTimer,
-                  child: const Text('Reset'),
-                ),
-                ElevatedButton(
-                  onPressed: finishTimer,
-                  child: const Text('finish'),
+                Expanded(
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(50),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5),
+                      ),
+                      backgroundColor: Theme.of(context).colorScheme.secondary,
+                    ),
+                    onPressed: finishTimer,
+                    child: Text(
+                      '종료하기',
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSecondary,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
                 ),
               ],
             ),

--- a/lib/features/flow/presentation/home/home_screen.dart
+++ b/lib/features/flow/presentation/home/home_screen.dart
@@ -70,19 +70,8 @@ class HomeScreen extends ConsumerWidget {
       loading: () => const Center(
         child: CircularProgressIndicator(),
       ),
-      error: (err, stackTrace) => Column(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          Center(
-            child: Text("플로우 목록을 불러오지 못했습니다: $err"),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              context.push("/flow_register");
-            },
-            child: const Text('플로우 만들러 가기'),
-          ),
-        ],
+      error: (err, stackTrace) => Center(
+        child: Text("플로우 목록을 불러오지 못했습니다: $err"),
       ),
     );
   }

--- a/lib/features/flow/presentation/home/home_screen.dart
+++ b/lib/features/flow/presentation/home/home_screen.dart
@@ -23,7 +23,7 @@ class HomeScreen extends ConsumerWidget {
                 onPressed: () {
                   context.push("/flow_register");
                 },
-                child: const Text('flow 생성'),
+                child: const Text('플로우 만들러 가기'),
               ),
             ],
           );
@@ -39,7 +39,7 @@ class HomeScreen extends ConsumerWidget {
                     trailing: ElevatedButton(
                       onPressed: () {
                         flowTimerNotifier.setFlowInfo(flowList[index]);
-                        context.push('/flow');
+                        context.go('/flow');
                       },
                       child: const Text("시작하기"),
                     ),
@@ -59,7 +59,7 @@ class HomeScreen extends ConsumerWidget {
               onPressed: () {
                 context.push("/flow_register");
               },
-              child: const Text('flow 생성'),
+              child: const Text('새 플로우 등록하기'),
             ),
             const SizedBox(
               height: 20,
@@ -70,8 +70,19 @@ class HomeScreen extends ConsumerWidget {
       loading: () => const Center(
         child: CircularProgressIndicator(),
       ),
-      error: (err, stackTrace) => Center(
-        child: Text("플로우 목록을 불러오지 못했습니다: $err"),
+      error: (err, stackTrace) => Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          Center(
+            child: Text("플로우 목록을 불러오지 못했습니다: $err"),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              context.push("/flow_register");
+            },
+            child: const Text('플로우 만들러 가기'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/flow/presentation/home/home_screen.dart
+++ b/lib/features/flow/presentation/home/home_screen.dart
@@ -21,7 +21,7 @@ class HomeScreen extends ConsumerWidget {
               const Text("아직 등록된 플로우가 없어요"),
               ElevatedButton(
                 onPressed: () {
-                  context.pushReplacement("/flow_register");
+                  context.push("/flow_register");
                 },
                 child: const Text('flow 생성'),
               ),
@@ -39,7 +39,7 @@ class HomeScreen extends ConsumerWidget {
                     trailing: ElevatedButton(
                       onPressed: () {
                         flowTimerNotifier.setFlowInfo(flowList[index]);
-                        context.go('/flow');
+                        context.push('/flow');
                       },
                       child: const Text("시작하기"),
                     ),
@@ -57,7 +57,7 @@ class HomeScreen extends ConsumerWidget {
             ),
             ElevatedButton(
               onPressed: () {
-                context.pushReplacement("/flow_register");
+                context.push("/flow_register");
               },
               child: const Text('flow 생성'),
             ),

--- a/lib/features/flow/presentation/home/home_screen.dart
+++ b/lib/features/flow/presentation/home/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_screen_provider.dart';
+import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_timer_provider.dart';
 import 'package:noti_flutter/features/flow/presentation/home/flow_list_provider.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -10,7 +10,7 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final flowListState = ref.watch(flowListProvider);
-    final flowScreenNotifier = ref.read(flowScreenProvider.notifier);
+    final flowScreenNotifier = ref.read(flowTimerProvider.notifier);
 
     return flowListState.when(
       data: (flowList) {

--- a/lib/features/flow/presentation/home/home_screen.dart
+++ b/lib/features/flow/presentation/home/home_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_timer_provider.dart';
 import 'package:noti_flutter/features/flow/presentation/home/flow_list_provider.dart';
-import 'package:noti_flutter/features/log_in/presentation/providers/user_provider.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -11,7 +10,7 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final flowListState = ref.watch(flowListProvider);
-    final flowScreenNotifier = ref.read(flowTimerProvider.notifier);
+    final flowTimerNotifier = ref.read(flowTimerProvider.notifier);
 
     return flowListState.when(
       data: (flowList) {
@@ -39,7 +38,7 @@ class HomeScreen extends ConsumerWidget {
                   return ListTile(
                     trailing: ElevatedButton(
                       onPressed: () {
-                        flowScreenNotifier.setFlowInfo(flowList[index]);
+                        flowTimerNotifier.setFlowInfo(flowList[index]);
                         context.go('/flow');
                       },
                       child: const Text("시작하기"),

--- a/lib/features/flow/presentation/register_flow/register_flow_screen.dart
+++ b/lib/features/flow/presentation/register_flow/register_flow_screen.dart
@@ -174,12 +174,6 @@ class _RegisterFlowScreenState extends ConsumerState<RegisterFlowScreen> {
                 ? const CircularProgressIndicator()
                 : const Text('Submit'),
           ),
-          ElevatedButton(
-            onPressed: () {
-              context.pushReplacement('/home');
-            },
-            child: const Text("돌아가기"),
-          )
         ],
       ),
     );

--- a/lib/features/log_in/presentation/log_in_screen.dart
+++ b/lib/features/log_in/presentation/log_in_screen.dart
@@ -89,15 +89,6 @@ class _LogInScreenState extends ConsumerState<LogInScreen> {
                         SnackBar(
                           content: Text(e.toString()),
                           backgroundColor: Colors.red,
-                          duration: const Duration(seconds: 20),
-                          action: SnackBarAction(
-                            label: '닫기',
-                            textColor: Colors.white,
-                            onPressed: () {
-                              ScaffoldMessenger.of(context)
-                                  .hideCurrentSnackBar();
-                            },
-                          ),
                         ),
                       );
                     }

--- a/lib/features/log_in/presentation/log_in_screen.dart
+++ b/lib/features/log_in/presentation/log_in_screen.dart
@@ -111,7 +111,7 @@ class _LogInScreenState extends ConsumerState<LogInScreen> {
             ),
             ElevatedButton(
               onPressed: () {
-                context.push('/sign_up');
+                context.go('/sign_up');
               },
               child: const Text("회원가입"),
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ class NotiFlutter extends ConsumerWidget {
     final ColorScheme colorScheme = ColorScheme.fromSeed(
       brightness: MediaQuery.platformBrightnessOf(context),
       seedColor: Colors.blue,
+      error: const Color(0xffef4444),
     );
     return MaterialApp.router(
       routerConfig: router,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,8 +36,7 @@ class NotiFlutter extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ColorScheme colorScheme = ColorScheme.fromSeed(
       brightness: MediaQuery.platformBrightnessOf(context),
-      seedColor: Colors.blue,
-      error: const Color(0xffef4444),
+      seedColor: const Color(0xFFFAFAFA),
     );
     return MaterialApp.router(
       routerConfig: router,
@@ -45,6 +44,47 @@ class NotiFlutter extends ConsumerWidget {
       theme: ThemeData(
         colorScheme: colorScheme,
         useMaterial3: true,
+        textTheme: const TextTheme(
+          displayLarge: TextStyle(
+            fontSize: 64,
+            fontWeight: FontWeight.bold,
+          ),
+          displayMedium: TextStyle(
+            fontSize: 45,
+            fontWeight: FontWeight.w600,
+          ),
+          displaySmall: TextStyle(
+            fontSize: 36,
+            fontWeight: FontWeight.w500,
+          ),
+          titleLarge: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.bold,
+          ),
+          titleMedium: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          ),
+          titleSmall: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.w500,
+          ),
+          bodyLarge: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.normal,
+            color: Colors.black,
+          ),
+          bodyMedium: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.normal,
+            color: Colors.black87,
+          ),
+          bodySmall: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.normal,
+            color: Colors.black54,
+          ),
+        ),
       ),
     );
   }

--- a/lib/router/go_router.dart
+++ b/lib/router/go_router.dart
@@ -22,13 +22,6 @@ final router = GoRouter(
       },
       routes: [
         GoRoute(
-          path: '/flow',
-          pageBuilder: (BuildContext context, GoRouterState state) =>
-              NoTransitionPage(
-            child: FlowScreen(),
-          ),
-        ),
-        GoRoute(
           path: '/home',
           pageBuilder: (BuildContext context, GoRouterState state) =>
               const NoTransitionPage(
@@ -67,6 +60,13 @@ final router = GoRouter(
           path: '/flow_register',
           pageBuilder: (BuildContext context, GoRouterState state) =>
               const NoTransitionPage(child: RegisterFlowScreen()),
+        ),
+        GoRoute(
+          path: '/flow',
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage(
+            child: FlowTimerScreen(),
+          ),
         ),
       ],
     ),

--- a/lib/router/go_router.dart
+++ b/lib/router/go_router.dart
@@ -74,9 +74,10 @@ final router = GoRouter(
 );
 
 const Map<String, String> routeTitles = {
-  '/flow': 'Flow',
-  '/home': 'Home',
-  '/my_page': 'My Page',
-  '/sign_up': 'Sign Up',
-  '/log_in': 'Log In',
+  '/flow': '플로우',
+  '/home': '플로우 목록',
+  '/my_page': '마이 페이지',
+  '/sign_up': '회원가입',
+  '/log_in': '로그인',
+  '/flow_register': "플로우 등록"
 };

--- a/lib/router/go_router.dart
+++ b/lib/router/go_router.dart
@@ -3,7 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:noti_flutter/features/log_in/presentation/log_in_screen.dart';
 import 'package:noti_flutter/features/flow/presentation/register_flow/register_flow_screen.dart';
 import 'package:noti_flutter/features/sign_up/presentation/sign_up_screen.dart';
-import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_screen.dart';
+import 'package:noti_flutter/features/flow/presentation/flow_screen/flow_timer_screen.dart';
 import 'package:noti_flutter/widgets/bottom_navigation_bar_layout.dart';
 import 'package:noti_flutter/features/flow/presentation/home/home_screen.dart';
 import 'package:noti_flutter/features/flow/presentation/my_page/my_page_screen.dart';

--- a/lib/widgets/bottom_navigation_bar_layout.dart
+++ b/lib/widgets/bottom_navigation_bar_layout.dart
@@ -33,9 +33,6 @@ class BottomNavigationBarLayout extends StatelessWidget {
               router.go('/home');
               break;
             case 1:
-              router.go('/flow');
-              break;
-            case 2:
               router.go('/my_page');
               break;
           }
@@ -44,10 +41,6 @@ class BottomNavigationBarLayout extends StatelessWidget {
           BottomNavigationBarItem(
             icon: Icon(Icons.home),
             label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.schedule),
-            label: 'Flow',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.dashboard),
@@ -63,11 +56,8 @@ class BottomNavigationBarLayout extends StatelessWidget {
     if (location?.startsWith('/home') ?? false) {
       return 0;
     }
-    if (location?.startsWith('/flow') ?? false) {
-      return 1;
-    }
     if (location?.startsWith('/my_page') ?? false) {
-      return 2;
+      return 1;
     }
     return 0;
   }


### PR DESCRIPTION
## 플로우 타이머 실행 기능 구현
### 동작 순서
1. HomeScreen 
폴더 구조: features/flow/presentation/home
- 플로우 목록에서 플로우를 선택 시, FlowTimerScreen으로 이동.
   이때 flowTimerNotifier.setFlowInfo를 호출해 FlowState를 선택된 flow의 데이터로 초기화함.

2. FlowTimerScreen
폴더 구조:  features/flow/presentation/flow_screen
- 기존에 initState에서 ref.read로 제한 시간을 초기화 하던 것을, build메서드 내에서 ref.watch()로 초기화 하도록 변경함.
- build 메서드에서 ref.watch(flowTimerProvider)로 선택된 flow의 상태를 참조하고, 
   isFocusTIme이라는 위젯 내 상태 변수로 각 단계에 맞는 timeLimit과 ui를 결정함.

### 화면 설명
FlowTimerScreen

타이머는 1단계 집중 시간, 2단계 휴식 시간으로 이루어져 있음.
타이머는 '시작하기'와 '일시정지' / '이전 단계로 돌아가기'와 '다음 단계로 건너뛰기' 기능을 갖고 있음.
하단의 '종료하기' 버튼을 누르면 현재 몇 회차까지 진행했는지, 그리고 기록을 저장하고 종료 할건지 저장하지 않고 종료 할건지를 선택하도록 함.

## 그외 수정한 부분
### go_router.dart, bottom_navigation_bar_layout.dart
바텀 내비게이션바를 홈, 마이페이지 2개로 줄임

### main.dart
textTheme에 사용할 스타일들 추가